### PR TITLE
Fixes for urllib.request and sys.exc_info

### DIFF
--- a/glsapiutil/glsapiutil3.py
+++ b/glsapiutil/glsapiutil3.py
@@ -242,7 +242,7 @@ class glsapiutil3:
         req = py_sys_urllib.Request( uri )
 
         if xmlObject is not None:
-            req.add_data( xmlObject )
+            req.data = xmlObject.encode('utf-8')
         
         req.get_method = lambda: http_method_type
         req.add_header( 'Accept', 'application/xml' )
@@ -270,7 +270,8 @@ class glsapiutil3:
 
 
         except:
-            responseText = '%s %s' % ( str(sys.exc_type), str(sys.exc_value) )
+            exctype, excvalue = sys.exc_info()[:2]
+            responseText = '%s %s' % (str(exctype), str(excvalue))
 
         return responseText
 


### PR DESCRIPTION
### Why?

In Python 3.4 and up `urllib.request` no longer has an `add_data` method. According to the [documentation](https://docs.python.org/3/library/urllib.request.html#urllib.request.Request.data) we can directly assign the encoded XML string to `urllib.request.data` attribute.

Similarly `sys.exc_type` and `sys.exc_value` are [deprecated](https://docs.python.org/2/library/sys.html)

